### PR TITLE
TransactionManager类，没有被任何类使用，删除无效代码

### DIFF
--- a/src/main/java/com/webank/wecross/transaction/TransactionManager.java
+++ b/src/main/java/com/webank/wecross/transaction/TransactionManager.java
@@ -1,3 +1,0 @@
-package com.webank.wecross.transaction;
-
-public interface TransactionManager {}


### PR DESCRIPTION
WeCross项目内，com.webank.wecross.transaction包的TransactionManager类，没有被任何类使用，删除